### PR TITLE
Separating out the PUBG AI Client to be able to use different models

### DIFF
--- a/src/Application/Features/PubgBackgroundService.cs
+++ b/src/Application/Features/PubgBackgroundService.cs
@@ -3,12 +3,12 @@ using Application.Infrastructure.Pubg;
 
 namespace Application.Features;
 
-public class PubgBackgroundService(IPubgApiClient pubgApiClient, IChatService chatService, ChatOptions options, IAIClient aiClient, ILogger<PubgBackgroundService> logger) : BackgroundService
+public class PubgBackgroundService(IPubgApiClient pubgApiClient, IChatService chatService, ChatOptions options, IPubgAIClient pubgAiClient, ILogger<PubgBackgroundService> logger) : BackgroundService
 {
     private readonly IPubgApiClient pubgApiClient = pubgApiClient;
     private readonly IChatService chatService = chatService;
     private readonly ChatOptions options = options;
-    private readonly IAIClient aiClient = aiClient;
+    private readonly IPubgAIClient pubgAiClient = pubgAiClient;
     private readonly ILogger<PubgBackgroundService> logger = logger;
     private HashSet<string> MatchIds = [];
 
@@ -41,17 +41,8 @@ public class PubgBackgroundService(IPubgApiClient pubgApiClient, IChatService ch
                     logger.LogInformation("New match found: {MatchId}", matchData.Id);
 
                     var match = await pubgApiClient.GetMatch(matchData.Id, stoppingToken);
-                    var response = await aiClient.GetCompletion(
-                        @"Look at this JSON match statistics from a PUBG game.
-                        Find who won the game, use the name attribute from the players that won.
-                        Indicate if was a solo, duo or squad game.
-                        Also find out how LittleAndi did in the game. " + JsonSerializer.Serialize(match, Infrastructure.Pubg.Models.Converter.Settings));
-                    await chatService.SendMessage(options.Channel, $"New game found! {response} ({matchData.Id})", stoppingToken);
-
-                    // Process the new match
-                    // await pubgApiClient.GetMatchDetails(matchData.Id, stoppingToken);
-                    // await pubgApiClient.GetMatchPlayerStats(matchData.Id, playerId, stoppingToken);
-                    // await pubgApiClient.GetMatchTelemetry(matchData.Id, stoppingToken);
+                    var response = await pubgAiClient.GetPubgCompletion(@"", match);
+                    await chatService.SendMessage(options.Channel, response, stoppingToken);
                 }
             }
         }

--- a/src/Application/Infrastructure/DependencyInjection.cs
+++ b/src/Application/Infrastructure/DependencyInjection.cs
@@ -8,6 +8,7 @@ public static class DependencyInjection
     {
         services.AddTwitch(configuration);
         services.AddOpenAI(configuration);
+        services.AddPubgOpenAI(configuration);
         services.AddPubg(configuration);
     }
 
@@ -32,6 +33,13 @@ public static class DependencyInjection
         return services;
     }
 
+    private static IServiceCollection AddPubgOpenAI(this IServiceCollection services, IConfiguration configuration)
+    {
+        services.AddConfigurationOptions<PubgOpenAIClientOptions>(configuration, out _);
+        services.AddSingleton<IPubgAIClient, PubgAIClient>();
+        return services;
+    }
+
     private static IServiceCollection AddPubg(this IServiceCollection services, IConfiguration configuration)
     {
         services.AddConfigurationOptions<PubgClientOptions>(configuration, out var pubgClientOptions);
@@ -44,4 +52,5 @@ public static class DependencyInjection
         services.AddTransient<IPubgApiClient, PubgApiClient>();
         return services;
     }
+
 }

--- a/src/Application/Infrastructure/OpenAI/AIClient.cs
+++ b/src/Application/Infrastructure/OpenAI/AIClient.cs
@@ -1,4 +1,4 @@
-using Application.Common;
+using System.Text.Json;
 using OpenAI.Chat;
 
 namespace Application.Infrastructure.OpenAI;
@@ -13,7 +13,7 @@ public class AIClient(OpenAIClientOptions options) : IAIClient
 {
     private readonly ChatClient client = new(options.Model, options.ApiKey);
 
-    private readonly string SystemPrompt = @"Your primary role on this Twitch channel is to facilitate and enhance the interactions between human users.
+    private readonly string GeneralSystemPrompt = @"Your primary role on this Twitch channel is to facilitate and enhance the interactions between human users.
             The vast majority of messages in the chat are conversations between users and the streamer.
             Your task is to observe these conversations and respond appropriately, supporting the streamer and the community.
             Respond like a teenage girl from California, but usually one or two sentences (max 500 characters).
@@ -22,7 +22,7 @@ public class AIClient(OpenAIClientOptions options) : IAIClient
 
     public async Task<string> GetAwareCompletion(IEnumerable<string> historyMessages)
     {
-        List<ChatMessage> chatMessages = [new SystemChatMessage(SystemPrompt)];
+        List<ChatMessage> chatMessages = [new SystemChatMessage(GeneralSystemPrompt)];
         chatMessages.AddRange(historyMessages.Select(msg => new UserChatMessage(msg)));
         ChatCompletion chatCompletion = await client.CompleteChatAsync([.. chatMessages]);
 
@@ -33,7 +33,7 @@ public class AIClient(OpenAIClientOptions options) : IAIClient
     {
         ChatCompletion chatCompletion = await client.CompleteChatAsync(
             [
-                new SystemChatMessage(SystemPrompt),
+                new SystemChatMessage(GeneralSystemPrompt),
                 new UserChatMessage(prompt),
             ]
         );

--- a/src/Application/Infrastructure/OpenAI/PubgAIClient.cs
+++ b/src/Application/Infrastructure/OpenAI/PubgAIClient.cs
@@ -1,0 +1,50 @@
+using System.Text.Json;
+using OpenAI.Chat;
+
+namespace Application.Infrastructure.OpenAI;
+
+public interface IPubgAIClient
+{
+    Task<string> GetPubgCompletion(string prompt, Pubg.Models.Match match);
+}
+
+public class PubgAIClient(PubgOpenAIClientOptions options) : IPubgAIClient
+{
+    private readonly ChatClient client = new(options.Model, options.ApiKey);
+
+    private readonly string PubgGameSystemPrompt = @"
+            Analyze LittleAndi performance. Account for the game type; solo, duo or squad.
+            If it is a solo game, analyze LittleAndi's performance and highlight any unique aspects of the gameplay.
+            If it is a squad or duo game, also analyze LittleAndi's team performance and highlight LittleAndi's contributions.
+            LittleAndi's team is the ones that is in the same roster as LittleAndi.
+            The 'relationships' and 'rosters' tells you about the groups of players playing together.
+            Each 'roster' got 'participants' which are the members of the groups (can also be solos).
+            If LittleAndi is not in the match as a participant, just create a general analysis of the game.
+            Keep your reponse under 450 chars at all costs.
+            You may use gamers lingo and shorten common words to keep response short.
+            Replace words with emojis where possible.
+    ";
+
+    public async Task<string> GetPubgCompletion(string prompt, Pubg.Models.Match match)
+    {
+        ChatCompletion chatCompletion = await client.CompleteChatAsync(
+            [
+                new SystemChatMessage(PubgGameSystemPrompt),
+                new UserChatMessage(
+                    ChatMessageContentPart.CreateTextPart(prompt),
+                    ChatMessageContentPart.CreateTextPart(JsonSerializer.Serialize(match, Infrastructure.Pubg.Models.Converter.Settings))
+                ),
+            ]
+        );
+
+        return new string(chatCompletion.Content[0].Text);
+    }
+}
+
+public class PubgOpenAIClientOptions : IConfigurationOptions
+{
+    public static string SectionName => "PubgOpenAI";
+
+    public string Model { get; set; } = string.Empty;
+    public string ApiKey { get; set; } = string.Empty;
+}

--- a/src/Host/appsettings.json
+++ b/src/Host/appsettings.json
@@ -33,6 +33,10 @@
     "SoundOutDeviceGuid": "#{SoundOutDeviceGuid}#",
     "AudioOutputPath": "#{AudioOutputPath}#"
   },
+  "PubgOpenAI": {
+    "Model": "#{Model}#",
+    "ApiKey": "#{OpenAIApiKey}#"
+  },
   "Pubg": {
     "BaseAddress": "#{PubgApiBaseAddress}#",
     "Platform": "#{Platform}#",


### PR DESCRIPTION
Seems like a more advanced models is suitable for the analysis of the PUBG match responses, like `gpt-4o` instead of `gpt-4o-mini`. Splitting up the clients to be able to use different models. Might be able to make the chat one generic in the future (since the Audio and Moderation clients are separate anyway.