### PR TITLE
Prompt config

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,9 +10,42 @@ be made during streaming at https://www.twitch.tv/littleandi77.
 We now got a basic bot that responds when mentioned, but also randomly responds to messages in chat.
 Also, we're trying out making it aware of some of the chat history, but this seems to require some tuning.
 
+## Config
+
+### Prompts
+
+Currently supporting a separate `appsettings.prompts.json` that can be (but not need to be) used to configure the system prompts.
+The Pubg AI will besides the system prompt be fed with the json payload from the /matches endpoint in the PUBG API.
+
+```json
+{
+  "OpenAI": {
+    "GeneralSystemPrompt": "Be kind"
+  },
+  "PubgOpenAI": {
+    "PubgGameSystemPrompt": ""
+  }
+}
+```
+
 ## Auth
 
-Scopes needed `user:bot chat:edit chat:read channel:bot whispers:read clips:edit`
+Scopes needed (configured in appsettings):
+
+- "bits:read",
+- "channel:bot",
+- "channel:manage:predictions",
+- "channel:manage:redemptions",
+- "channel:read:ads",
+- "channel:read:redemptions",
+- "channel:read:subscriptions",
+- "channel:read:vips",
+- "chat:edit",
+- "chat:read",
+- "clips:edit",
+- "moderator:read:followers",
+- "user:bot",
+- "whispers:read"
 
 ## Getting Started
 

--- a/src/Application/GlobalUsings.cs
+++ b/src/Application/GlobalUsings.cs
@@ -8,6 +8,7 @@ global using Microsoft.Extensions.Configuration;
 global using Microsoft.Extensions.DependencyInjection;
 global using Microsoft.Extensions.Hosting;
 global using Microsoft.Extensions.Logging;
+global using Microsoft.Extensions.Options;
 global using OpenAI;
 global using OpenAI.Audio;
 global using System.Text.RegularExpressions;

--- a/src/Application/Infrastructure/DependencyInjection.cs
+++ b/src/Application/Infrastructure/DependencyInjection.cs
@@ -13,7 +13,7 @@ public static class DependencyInjection
 
     private static IServiceCollection AddTwitch(this IServiceCollection services, IConfiguration configuration)
     {
-        services.AddConfigurationOptions<ChatOptions>(configuration, out _);
+        services.AddConfigurationOptions<ChatOptions>(configuration);
         services.AddSingleton<IChatService, ChatService>();
         services.AddSingleton<IClipService, ClipService>();
         services.AddSingleton<IMonitorService, MonitorService>();
@@ -25,7 +25,7 @@ public static class DependencyInjection
 
     private static IServiceCollection AddOpenAI(this IServiceCollection services, IConfiguration configuration)
     {
-        services.AddConfigurationOptions<OpenAI.OpenAIClientOptions>(configuration, out _);
+        services.AddConfigurationOptions<OpenAI.OpenAIClientOptions>(configuration);
         services.AddSingleton<IAIClient, AIClient>();
         services.AddSingleton<IAudioClient, OpenAI.AudioClient>();
         services.AddSingleton<IModerationClient, ModerationClient>();
@@ -34,16 +34,17 @@ public static class DependencyInjection
 
     private static IServiceCollection AddPubgOpenAI(this IServiceCollection services, IConfiguration configuration)
     {
-        services.AddConfigurationOptions<PubgOpenAIClientOptions>(configuration, out _);
+        services.AddConfigurationOptions<PubgOpenAIClientOptions>(configuration);
         services.AddSingleton<IPubgAIClient, PubgAIClient>();
         return services;
     }
 
     private static IServiceCollection AddPubg(this IServiceCollection services, IConfiguration configuration)
     {
-        services.AddConfigurationOptions<PubgClientOptions>(configuration, out var pubgClientOptions);
+        services.AddConfigurationOptions<PubgClientOptions>(configuration);
         services.AddHttpClient("pubg", (ServiceProvider, client) =>
         {
+            var pubgClientOptions = ServiceProvider.GetRequiredService<IOptionsMonitor<PubgClientOptions>>().CurrentValue;
             client.BaseAddress = new Uri(pubgClientOptions.BaseAddress);
             client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", pubgClientOptions.ApiKey);
             client.DefaultRequestHeaders.Add("Accept", "application/vnd.api+json");

--- a/src/Host/Host.csproj
+++ b/src/Host/Host.csproj
@@ -26,6 +26,7 @@
     <None Update="appsettings.Test.json" CopyToOutputDirectory="PreserveNewest" CopyToPublishDirectory="Never" />
     <None Update="appsettings.Production.json" CopyToOutputDirectory="PreserveNewest" CopyToPublishDirectory="Never" />
     <None Update="appsettings.json" CopyToOutputDirectory="PreserveNewest" CopyToPublishDirectory="Never" />
+    <None Update="appsettings.prompts.json" CopyToOutputDirectory="PreserveNewest" CopyToPublishDirectory="Always" />
   </ItemGroup>
   
 </Project>

--- a/src/Host/Program.cs
+++ b/src/Host/Program.cs
@@ -6,6 +6,7 @@
 try
 {
     var builder = WebApplication.CreateBuilder(args);
+    builder.Configuration.AddJsonFile("appsettings.prompts.json", optional: true, reloadOnChange: true);
     builder.Services.AddApplication();
     builder.Services.AddInfrastructure(builder.Configuration);
     builder.Host.UseSerilog((hostContext, provider, loggerConfiguration) =>


### PR DESCRIPTION
Allow for the config to be in an additional config file `appsettings.prompts.json` to separate those into it's own file.
This is just another general config file, but it is good to have the prompts in a separate file if you working with the prompts while sharing screen och streaming. Then you don't have to show the rest of the config at the same time.
This feature also enables the config to be reloaded on change so you can update the prompts while running.