### PR TITLE
Add and use a simplified pubg model to cut down on tokens used

### DIFF
--- a/src/Application/Features/PubgBackgroundService.cs
+++ b/src/Application/Features/PubgBackgroundService.cs
@@ -41,7 +41,7 @@ public class PubgBackgroundService(IPubgApiClient pubgApiClient, IChatService ch
                     logger.LogInformation("New match found: {MatchId}", matchData.Id);
 
                     var match = await pubgApiClient.GetMatch(matchData.Id, stoppingToken);
-                    var response = await pubgAiClient.GetPubgCompletion(@"", match);
+                    var response = await pubgAiClient.GetPubgCompletion(@"", match, "LittleAndi");
                     await chatService.SendMessage(options.Channel, response, stoppingToken);
 
                     // Play audio

--- a/src/Application/GlobalUsings.cs
+++ b/src/Application/GlobalUsings.cs
@@ -12,6 +12,7 @@ global using Microsoft.Extensions.Options;
 global using OpenAI;
 global using OpenAI.Assistants;
 global using OpenAI.Audio;
+global using System.Text.Json;
 global using System.Text.RegularExpressions;
 global using TwitchLib.Client.Models;
 global using TwitchLib.EventSub.Websockets;

--- a/src/Application/Infrastructure/OpenAI/PubgAIClient.cs
+++ b/src/Application/Infrastructure/OpenAI/PubgAIClient.cs
@@ -5,7 +5,7 @@ namespace Application.Infrastructure.OpenAI;
 
 public interface IPubgAIClient
 {
-    Task<string> GetPubgCompletion(string prompt, Pubg.Models.Match match);
+    Task<string> GetPubgCompletion(string prompt, Pubg.Models.Match match, string mainParticipantName);
 }
 
 public class PubgAIClient(IOptionsMonitor<PubgOpenAIClientOptions> optionsMonitor, ILogger<PubgAIClient> logger) : IPubgAIClient
@@ -15,15 +15,17 @@ public class PubgAIClient(IOptionsMonitor<PubgOpenAIClientOptions> optionsMonito
     private long totalInputTokenCount = 0;
     private long totalOutputTokenCount = 0;
 
-    public async Task<string> GetPubgCompletion(string prompt, Pubg.Models.Match match)
+    public async Task<string> GetPubgCompletion(string prompt, Pubg.Models.Match match, string mainParticipantName)
     {
+        var pubgAIMatchModel = PubgAIMatchModel.FromMatch(match, mainParticipantName);
+
         var options = optionsMonitor.CurrentValue;
         ChatCompletion chatCompletion = await client.CompleteChatAsync(
             [
                 new SystemChatMessage(options.PubgGameSystemPrompt),
                 new UserChatMessage(
                     ChatMessageContentPart.CreateTextPart(prompt),
-                    ChatMessageContentPart.CreateTextPart(JsonSerializer.Serialize(match, Infrastructure.Pubg.Models.Converter.Settings))
+                    ChatMessageContentPart.CreateTextPart(JsonSerializer.Serialize(pubgAIMatchModel, Infrastructure.Pubg.Models.Converter.Settings))
                 ),
             ]
         );

--- a/src/Application/Infrastructure/OpenAI/PubgAIMatchModel.cs
+++ b/src/Application/Infrastructure/OpenAI/PubgAIMatchModel.cs
@@ -1,0 +1,114 @@
+namespace Application.Infrastructure.OpenAI;
+
+public record PubgAIMatchModel(MatchData MatchData, TeamData TeamData, IEnumerable<Participant> TeamParticipants)
+{
+    public static PubgAIMatchModel FromMatch(Pubg.Models.Match match, string mainParticipantName)
+    {
+        // Find the participants of the team (roster)
+        var mainParticipant = match.Included.First(i => i.Type == Pubg.Models.TypeEnum.Participant && i.Attributes.Stats.Name == mainParticipantName);
+        var roster = match.Included.First(i => i.Type == Pubg.Models.TypeEnum.Roster && i.Relationships.Participants.Data.Any(p => p.Id == mainParticipant.Id));
+        List<Participant> rosterParticipants = [];
+
+        foreach (var participantData in roster.Relationships.Participants.Data)
+        {
+            var participant = match.Included.First(i => i.Type == Pubg.Models.TypeEnum.Participant && i.Id == participantData.Id);
+            rosterParticipants.Add(Participant.FromParticipant(participant.Attributes.Stats));
+        }
+
+        return new PubgAIMatchModel(MatchData.FromMatch(match.Data), TeamData.FromRoster(roster), rosterParticipants);
+    }
+}
+
+public record MatchData(
+    string MatchType,
+    long Duration,
+    string GameMode,
+    string MapName,
+    bool IsCustomMatch,
+    string TitleId
+)
+{
+    public static MatchData FromMatch(Pubg.Models.Data matchData)
+    {
+        return new MatchData(
+            MatchType: matchData.Attributes.MatchType,
+            Duration: matchData.Attributes.Duration,
+            GameMode: matchData.Attributes.GameMode,
+            MapName: matchData.Attributes.MapName,
+            IsCustomMatch: matchData.Attributes.IsCustomMatch,
+            TitleId: matchData.Attributes.TitleId
+        );
+    }
+}
+
+public record TeamData(
+    long? TeamId,
+    long? Rank,
+    bool? Won
+)
+{
+    public static TeamData FromRoster(Pubg.Models.Included roster)
+    {
+        return new TeamData(
+            TeamId: roster.Attributes.Stats.TeamId,
+            Rank: roster.Attributes.Stats.Rank,
+            Won: roster.Attributes.Won
+        );
+    }
+}
+
+public record Participant(
+    string Name,
+    string PlayerId,
+    long? KillPlace,
+    long? WinPlace,
+    long? Kills,
+    long? Assists,
+    double? DamageDealt,
+    long? Heals,
+    long? Revives,
+    long? Boosts,
+    long? WeaponsAcquired,
+    double? WalkDistance,
+    double? RideDistance,
+    double? SwimDistance,
+    long? TimeSurvived,
+    long? RoadKills,
+    long? TeamKills,
+    long? HeadshotKills,
+    double? LongestKill,
+    long? VehicleDestroys,
+    long? DbnOs,
+    long? KillStreaks,
+    string? DeathType
+)
+{
+    public static Participant FromParticipant(Pubg.Models.Stats participant)
+    {
+        return new Participant(
+            Name: participant.Name,
+            PlayerId: participant.PlayerId,
+            KillPlace: participant.KillPlace,
+            WinPlace: participant.WinPlace,
+            Kills: participant.Kills,
+            Assists: participant.Assists,
+            DamageDealt: participant.DamageDealt,
+            Heals: participant.Heals,
+            Revives: participant.Revives,
+            Boosts: participant.Boosts,
+            WeaponsAcquired: participant.WeaponsAcquired,
+            WalkDistance: participant.WalkDistance,
+            RideDistance: participant.RideDistance,
+            SwimDistance: participant.SwimDistance,
+            TimeSurvived: participant.TimeSurvived,
+            RoadKills: participant.RoadKills,
+            TeamKills: participant.TeamKills,
+            HeadshotKills: participant.HeadshotKills,
+            LongestKill: participant.LongestKill,
+            VehicleDestroys: participant.VehicleDestroys,
+            DbnOs: participant.DbnOs,
+            KillStreaks: participant.KillStreaks,
+            DeathType: participant.DeathType.ToString()
+        );
+    }
+}


### PR DESCRIPTION
Cutting down on the total token count usage from ~25k to ~1k for each pubg completion request. This way we can also now use a more expensive model.